### PR TITLE
ClipboardAll is not supported inside comma-separated expressions

### DIFF
--- a/Tools/HtmlTag.ahk
+++ b/Tools/HtmlTag.ahk
@@ -115,7 +115,8 @@ HtmlTag(Mask, DelimChar="|", Textpoint=1, Caret_withText=0){
 	static clipjumpcall := IsFunc("CjControl") ? 1 : 0 , cj := "CjControl"		;Clipjump mamagement . Will not affect speed if Clipjump is not running
 	;OR ClipjumpCommuniator.ahk is not included
 
-	oldclip := ClipboardAll , T := clipjumpcall ? Cj.(0) : ""
+	oldclip := ClipboardAll
+	T := clipjumpcall ? Cj.(0) : ""
 
 	Clipboard := emptyvar
 	Send, ^c
@@ -145,7 +146,7 @@ HtmlTag(Mask, DelimChar="|", Textpoint=1, Caret_withText=0){
 		ClipWait
 		Send, ^v
 	}
-	Else SendPlay {RAW} %ToSend%
+	Else SendPlay {RAW}%ToSend%
 
 	Clipboard := oldclip
 


### PR DESCRIPTION
As mentioned [here](https://autohotkey.com/docs/misc/Clipboard.htm#Notes) ClipboardAll is not supported inside comma-separated expressions.
+removed an extra space I was added before